### PR TITLE
[Bugfix] Fix Download Button Spacing

### DIFF
--- a/src/pages/components/DownloadButton.js
+++ b/src/pages/components/DownloadButton.js
@@ -3,8 +3,7 @@ import React from 'react';
 const DownloadButton = ({ src, alt, upperText, lowerText, link }) => {
   return (
     <button
-      className='bg-dark-ash text-white w-[165px] h-[48px] rounded p-2 font-bold mx-2 
-        desktop:mx-0 desktop:mr-4 lg:mr-5 lg:ml-0'
+      className='bg-dark-ash text-white w-[165px] h-[48px] rounded p-2 font-bold desktop:mx-0'
       onClick={() => (window.location.href = link)}
     >
       <div className='flex items-center'>

--- a/src/pages/components/MainHeadline.js
+++ b/src/pages/components/MainHeadline.js
@@ -25,7 +25,7 @@ const MainHeadline = () => {
           furbaby instead. With <span className='text-yellow-900'>swipet</span>,
           you get the love you deserve.
         </h3>
-        <div className='flex justify-center'>
+        <div className='flex justify-center space-x-3 lg:space-x-4'>
           <DownloadButton
             src='./images/GooglePlay.svg'
             alt='google play store'

--- a/src/pages/components/footerSection/index.js
+++ b/src/pages/components/footerSection/index.js
@@ -13,7 +13,7 @@ const FooterSection = () => {
               waiting for <span className='text-yellow-900'>you</span>
             </p>
           </div>
-          <div className='flex justify-center'>
+          <div className='flex justify-center space-x-3 lg:space-x-4'>
             <DownloadButton
               src='./images/GooglePlay.svg'
               alt='google play store'


### PR DESCRIPTION
## Related Links

- Task Link: https://www.notion.so/Fix-Download-Button-Spacing-019459903ff042d3a6c97e2d0dfdbb80
- Route Link: /

## Description

- Center the Download Buttons in the Bottom Banner

## Notes
- Added necessary fixes to the general download button containers, including the main headline so both sections display buttons correctly

## Screenshots
**Small Screen (iPhone 12 mini)**
<img width="342" alt="image" src="https://user-images.githubusercontent.com/20994464/166204338-ff08a354-34eb-4cdd-95b9-f8e6e6b51d66.png"> <img width="342" alt="image" src="https://user-images.githubusercontent.com/20994464/166204418-da4b8346-250f-4214-8bf1-1be3a9dd59b7.png">

**Medium Screen (Tablet)**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/20994464/166204499-3d81d9e7-0573-4895-b3df-9b66a4e2191b.png"> <img width="400" alt="image" src="https://user-images.githubusercontent.com/20994464/166204666-5ba1f0d1-2e61-4030-aba0-4001905509df.png">

**Large Screen (Laptop)**
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/20994464/166204871-409b27c2-f3aa-4bf4-9ac1-fdf4a8b47931.png">
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/20994464/166204960-1b93dd8d-17db-4278-8968-94a44003b44a.png">