### PR TITLE
[Task] Add meta description to pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,8 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A landing page promoting the fictitious application called 'Swipet,' a pet adoption app."
+      data-rh="true"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +25,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Swipet</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import { HelmetProvider, Helmet } from 'react-helmet-async';
+import { HelmetProvider } from 'react-helmet-async';
 import './assets/tailwind.output.css';
 import ScrollToTop from './pages/components/ScrollToTop';
 import Home from './pages/Home';
@@ -16,10 +16,6 @@ const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <HelmetProvider>
     <React.StrictMode>
-      <Helmet>
-        <title>Swipet</title>
-      </Helmet>
-
       <Router>
         <ScrollToTop>
           <Routes>

--- a/src/pages/components/MetaDecorator.js
+++ b/src/pages/components/MetaDecorator.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+
+const MetaDecorator = ({ title, content }) => {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name='description' content={content} />
+    </Helmet>
+  );
+};
+
+export default MetaDecorator;

--- a/src/pages/components/externalPages/AboutPage.js
+++ b/src/pages/components/externalPages/AboutPage.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import ExternalPageTemplate from './ExternalPageTemplate';
+import MetaDecorator from '../MetaDecorator';
 import { aboutPageConstant } from '../../../utilities/constants';
-import { Helmet } from 'react-helmet-async';
+import { aboutMetaData } from '../../../utilities/constants';
 
 const AboutSwipet = () => {
   const listItems = aboutPageConstant[5].text.map((list, index) => (
@@ -10,9 +11,10 @@ const AboutSwipet = () => {
 
   return (
     <ExternalPageTemplate title='About Swipet'>
-      <Helmet>
-        <title>About Swipet</title>
-      </Helmet>
+      <MetaDecorator
+        title={aboutMetaData.title}
+        content={aboutMetaData.content}
+      />
 
       {aboutPageConstant.map((item, index) => {
         return (

--- a/src/pages/components/externalPages/FaqPage.js
+++ b/src/pages/components/externalPages/FaqPage.js
@@ -1,14 +1,13 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
 import ExternalPageTemplate from './ExternalPageTemplate';
+import MetaDecorator from '../MetaDecorator';
 import { faqConstant } from '../../../utilities/constants';
+import { faqMetaData } from '../../../utilities/constants';
 
 const FaqPage = () => {
   return (
     <ExternalPageTemplate title='FAQs About Pet Adoption'>
-      <Helmet>
-        <title>FAQs</title>
-      </Helmet>
+      <MetaDecorator title={faqMetaData.title} content={faqMetaData.content} />
 
       {faqConstant.map((item, index) => {
         return (

--- a/src/pages/components/externalPages/NotFound.js
+++ b/src/pages/components/externalPages/NotFound.js
@@ -1,15 +1,17 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
 import { useNavigate } from 'react-router-dom';
+import MetaDecorator from '../MetaDecorator';
+import { notFoundMetaData } from '../../../utilities/constants';
 
 const NotFound = () => {
   const navigate = useNavigate();
 
   return (
     <div className='h-screen flex flex-col justify-center items-center px-5 md:px-[100px]'>
-      <Helmet>
-        <title>404</title>
-      </Helmet>
+      <MetaDecorator
+        title={notFoundMetaData.title}
+        content={notFoundMetaData.content}
+      />
 
       <img
         className='w-[350px] mb-12'

--- a/src/pages/components/externalPages/PrivacyPolicyPage.js
+++ b/src/pages/components/externalPages/PrivacyPolicyPage.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
 import ExternalPageTemplate from './ExternalPageTemplate';
+import MetaDecorator from '../MetaDecorator';
 import { privacyPolicyConstant } from '../../../utilities/constants';
+import { policyMetaData } from '../../../utilities/constants';
 
 const PrivacyPolicyPage = () => {
   const listItems = privacyPolicyConstant[11].text.map((list, index) => (
@@ -10,9 +11,10 @@ const PrivacyPolicyPage = () => {
 
   return (
     <ExternalPageTemplate title='Privacy Policy for Swipet'>
-      <Helmet>
-        <title>Privacy Policy</title>
-      </Helmet>
+      <MetaDecorator
+        title={policyMetaData.title}
+        content={policyMetaData.content}
+      />
 
       {privacyPolicyConstant.map((item, index) => {
         return (

--- a/src/pages/components/externalPages/TermsAndConditionsPage.js
+++ b/src/pages/components/externalPages/TermsAndConditionsPage.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { Helmet } from 'react-helmet-async';
 import ExternalPageTemplate from './ExternalPageTemplate';
+import MetaDecorator from '../MetaDecorator';
 import { termsAndConditionsConstant } from '../../../utilities/constants';
+import { termServiceMetaData } from '../../../utilities/constants';
 
 const TermsAndConditionsPage = () => {
   const allUlTags = termsAndConditionsConstant.filter(
@@ -17,9 +18,10 @@ const TermsAndConditionsPage = () => {
 
   return (
     <ExternalPageTemplate title='Terms and Conditions'>
-      <Helmet>
-        <title>Terms & Conditions</title>
-      </Helmet>
+      <MetaDecorator
+        title={termServiceMetaData.title}
+        content={termServiceMetaData.content}
+      />
 
       {termsAndConditionsConstant.map((item, index) => {
         return (

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -606,13 +606,13 @@ export const termsAndConditionsConstant = [
 export const aboutMetaData = {
   title: 'About Swipet',
   content:
-    'Swipet is a mobile application that pets (tinder pets) with their new forever homes. Swipet assured that finding a four-legged partner is quick, exciting, and addicting for pet lovers by combining strong location-based technology with the Swipe user interface popularized by applications like Tinder.',
+    'Swipet is a mobile application that connect pets with their new forever homes that combines location-based and swipe technology popularized by dating apps like Tinder.',
 };
 
 export const faqMetaData = {
   title: 'FAQs',
   content:
-    "Thank you for choosing to adopt a pet! We'll be there for you every step of the way. Learn the answers to the most frequently asked questions about adopting a pet through Swipet.",
+    "We'll be there for you every step of the way. Learn the answers to the most frequently asked questions about adopting a pet through Swipet.",
 };
 
 export const termServiceMetaData = {

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -63,7 +63,7 @@ export const testimonials = [
   {
     name: 'Child hugging dog.',
     src: '/images/Test05.jpg',
-    text: "My new pet is my new bestfriend, thank you Swipet.",
+    text: 'My new pet is my new bestfriend, thank you Swipet.',
     author: 'Fumihito',
   },
 ];
@@ -602,3 +602,32 @@ export const termsAndConditionsConstant = [
     text: 'As long as the website and the information and services on the website are provided free of charge, we will not be liable for any loss or damage of any nature.',
   },
 ];
+
+export const aboutMetaData = {
+  title: 'About Swipet',
+  content:
+    'Swipet is a mobile application that pets (tinder pets) with their new forever homes. Swipet assured that finding a four-legged partner is quick, exciting, and addicting for pet lovers by combining strong location-based technology with the Swipe user interface popularized by applications like Tinder.',
+};
+
+export const faqMetaData = {
+  title: 'FAQs',
+  content:
+    "Thank you for choosing to adopt a pet! We'll be there for you every step of the way. Learn the answers to the most frequently asked questions about adopting a pet through Swipet.",
+};
+
+export const termServiceMetaData = {
+  title: 'Terms & Conditions',
+  content:
+    'The following Terms & Conditions form a legal agreement between you and Swipet. You must agree to all of the terms in order to use our service.',
+};
+
+export const policyMetaData = {
+  title: 'Privacy Policy',
+  content:
+    'You understand that by using or accessing the Services in any way, you accept the practices and policies mentioned in this Privacy Policy.',
+};
+
+export const notFoundMetaData = {
+  title: '404',
+  content: "Wooofs! We can't sniff out the page you're looking for.",
+};


### PR DESCRIPTION
## Related Links

- Task Link: https://www.notion.so/Research-how-to-improve-SEO-with-react-helmet-and-react-snap-544d2cfd68854d4f992f325cb5a07603

## Description
- Add meta description to pages

## Notes
- I tried to implement react-snap to pre-renders HTML but it's not compatible with react 18 unless we downgrade.

## Steps 
- Visit home and other pages
- Open developer tools and inspect element
- Check the title and meta description in the <head> tag
- Page title and meta description to the page should display

## Screenshots
![image](https://user-images.githubusercontent.com/79126024/167108219-a7f3de2d-7957-4fc0-b973-125cff9d2eb0.png)

