### PR TITLE
[Bugfix] Fix Content Overflow on Mobile

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -8,7 +8,7 @@ import CookiePolicy from './components/CookiePolicy';
 
 const Home = () => {
   return (
-    <div>
+    <div className='overflow-x-hidden'>
       <MainHeadline />
       <ContactUs />
       <FeatureSection />

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -63,7 +63,7 @@ export const testimonials = [
   {
     name: 'Child hugging dog.',
     src: '/images/Test05.jpg',
-    text: "My new pet is my new bestfriend, thank you Swipet.",
+    text: 'My new pet is my new bestfriend, thank you Swipet.',
     author: 'Fumihito',
   },
 ];
@@ -282,7 +282,7 @@ export const privacyPolicyConstant = [
   },
   {
     isPTag: true,
-    text: 'For more general information on cookies, please read https://www.generateprivacypolicy.com/#cookies the Cookies article on Generate Privacy Policy website </a> .',
+    text: 'For more general information on cookies, please read https://www.generateprivacypolicy.com/ the Cookies article on Generate Privacy Policy website.',
   },
   {
     isH3Tag: true,


### PR DESCRIPTION
## Related Links

- Task Link: https://www.notion.so/Bugfix-Fix-Content-Overflow-on-Mobile-03d5a6b392ef466c843c732f36805a4b

## Description
- Content overflows to the size and scroll is not displayed
- There should be content overflow

## Notes
- N/A

# Steps
- Go to any external pages (/about-swipet, /faq, etc.)
- Click the logo in the header
- Try to drag left and right
- There should be content overflow

## Screenshots
![bugfix-fix-content-overflow](https://user-images.githubusercontent.com/79126024/167534476-72496026-fcd6-4dd9-9262-31be33a34684.gif)


