### PR TITLE
[Task] Add space at the bottom of features on mobile

### DIFF
--- a/src/pages/components/feature/FeatureCard.js
+++ b/src/pages/components/feature/FeatureCard.js
@@ -49,7 +49,7 @@ const FeatureCard = ({ item, index, length }) => {
             <h3 className='mb-0 text-center font-semibold text-navy-900 sm:text-left sm:text-[32px] md:mb-4'>
               {item.title}
             </h3>
-            <p className='text-justify text-brown-900 sm:text-xl md:w-full md:text-left'>
+            <p className='mb-12 text-justify text-brown-900 sm:text-xl md:w-full md:text-left'>
               {item.description}
             </p>
           </div>


### PR DESCRIPTION
## Related Links

- Task Link: https://app.asana.com/0/1202252431396579/1202281341031088/f
- Route Link: '/'

## Description

- Add space at the bottom of features on mobile
- The last text for the features is too close to the bottom

## Notes

N/A

## Screenshots
</details>

<details>
<summary>iPhone</summary>

![image](https://user-images.githubusercontent.com/89514595/168548817-08465a1f-fa45-493e-81a9-536ce0511ae1.png)
![image](https://user-images.githubusercontent.com/89514595/168548871-8e3024cf-22f5-4f5e-8d98-d9ff71cfb1a0.png)

</details>
<details>
<summary>Responsive</summary>

![image](https://user-images.githubusercontent.com/89514595/168550072-220e510b-131e-473d-b2e7-0594c5c10441.png)

</details>